### PR TITLE
Migrate to Azure Managed Redis and Java 25

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   app:
     container_name: javadev
-    image: mcr.microsoft.com/devcontainers/java:1-21-bullseye
+    image: mcr.microsoft.com/devcontainers/java:25-bookworm
     environment: 
       # NOTE: MONGODB_HOST/DATABASE/USER/PASSWORD should match values in db container
       MONGODB_URI: mongodb://${ENV_DB_USER}:${ENV_DB_PASSWORD}@db:27017/${ENV_DB_DATABASE}?authSource=admin

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -160,7 +160,7 @@ resource privateDnsZoneDB 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   }
 }
 
-// Resources needed to secure Redis Cache behind a private endpoint
+// Resources needed to secure Azure Managed Redis behind a private endpoint
 resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-04-01' = {
   name: '${appName}-cache-privateEndpoint'
   location: location
@@ -173,7 +173,7 @@ resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-04-01' = 
         name: '${appName}-cache-privateEndpoint'
         properties: {
           privateLinkServiceId: redisCache.id
-          groupIds: ['redisCache']
+          groupIds: ['redisEnterprise']
         }
       }
     ]
@@ -193,7 +193,7 @@ resource cachePrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-04-01' = 
   }
 }
 resource privateDnsZoneCache 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-  name: 'privatelink.redis.cache.windows.net'
+  name: 'privatelink.redisenterprise.cache.azure.net'
   location: 'global'
   dependsOn: [
     virtualNetwork
@@ -291,20 +291,23 @@ resource dbaccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
   }
 }
 
-// The Redis cache is configured to the minimum pricing tier
-resource redisCache 'Microsoft.Cache/Redis@2023-08-01' = {
+// Azure Managed Redis configured to the minimum pricing tier.
+resource redisCache 'Microsoft.Cache/redisEnterprise@2026-02-01-preview' = {
   name: '${appName}-cache'
   location: location
+  sku: {
+    name: 'Balanced_B0'
+  }
   properties: {
-    sku: {
-      name: 'Basic'
-      family: 'C'
-      capacity: 0
-    }
-    redisConfiguration: {}
-    enableNonSslPort: false
-    redisVersion: '6'
+    minimumTlsVersion: '1.2'
     publicNetworkAccess: 'Disabled'
+  }
+
+  resource redisDatabase 'databases@2026-02-01-preview' = {
+    name: 'default'
+    properties: {
+      accessKeysAuthentication: 'Enabled'
+    }
   }
 }
 
@@ -327,7 +330,7 @@ resource web 'Microsoft.Web/sites@2022-09-01' = {
   tags: {'azd-service-name': 'web'} // Needed by AZD
   properties: {
     siteConfig: {
-      linuxFxVersion: 'JAVA|21-java21' // Set to Java SE 21
+      linuxFxVersion: 'JAVA|25-java25' // Set to Java SE 25
       vnetRouteAllEnabled: true // Route outbound traffic to the VNET
       ftpsState: 'Disabled'
     }
@@ -442,7 +445,7 @@ resource cacheConnector 'Microsoft.ServiceLinker/linkers@2024-04-01' = {
     clientType: 'springBoot'
     targetService: {
       type: 'AzureResource'
-      id:  resourceId('Microsoft.Cache/Redis/Databases', redisCache.name, '0')
+      id: redisCache::redisDatabase.id
     }
     authInfo: {
       authType: 'accessKey' // Configure secrets as Key Vault references. No secret is exposed in App Service.


### PR DESCRIPTION
## What this does

Updates the infra template to use **Azure Managed Redis** (Redis Enterprise) instead of Azure Cache for Redis, and moves the runtime to **Java 25**. Mirrors the analogous changes in the JBoss/MySQL sample ([msdocs-jboss-mysql-sample-app#1](https://github.com/Azure-Samples/msdocs-jboss-mysql-sample-app/pull/1)).

### Infra (`infra/resources.bicep`)
- **Azure Cache for Redis → Azure Managed (Enterprise) Redis**
  - Resource type `Microsoft.Cache/Redis@2023-08-01` → `Microsoft.Cache/redisEnterprise@2026-02-01-preview` (`Balanced_B0`, `minimumTlsVersion: 1.2`, `publicNetworkAccess: Disabled`) with a nested `databases` resource named `default`.
  - Private endpoint `groupIds`: `redisCache` → `redisEnterprise`.
  - Private DNS zone: `privatelink.redis.cache.windows.net` → `privatelink.redisenterprise.cache.azure.net`.
  - Cache Service Connector target: `resourceId('Microsoft.Cache/Redis/Databases', …)` → `redisCache::redisDatabase.id` (still `clientType: springBoot`).
- **Java 25**: App Service `linuxFxVersion` `JAVA|21-java21` → `JAVA|25-java25`.

### Dev container (`.devcontainer/docker-compose.yml`)
- App image `java:1-21-bullseye` → `java:25-bookworm`.

### No application code changes
The Spring Boot app has no Redis client dependency (only `spring-boot-starter-web` + `spring-boot-starter-data-mongodb`); Redis is wired purely via the Service Connector (`spring.redis.*` app settings), so the Cache → Managed Redis swap is transparent. Java 25 is a runtime-only change.

## Validation
- `az bicep build` passes (only pre-existing `listConfigurations` output warnings).
- `azd up` succeeds end-to-end (App Service on Java 25, Cosmos DB, Managed Redis `Balanced_B0`, private endpoints, Service Connectors).
- Todo app verified live: home page loads and full CRUD (`POST`/`GET`/`DELETE /api/todolist`) round-trips through Cosmos DB (MongoDB API).

> [!NOTE]
> Managed Redis `Balanced_B0` + Cosmos + App Service quota availability varies by region/subscription. Deploy to a region where all three have capacity (`azd env set AZURE_LOCATION <region>`).
